### PR TITLE
Fix cannot read properties at startup

### DIFF
--- a/src/pages/agents/modal.tsx
+++ b/src/pages/agents/modal.tsx
@@ -160,7 +160,7 @@ export function AutorouteModal({
                       onValueChange={setSelectedRoutes}
                       value={selectedRoutes}
                     >
-                      {agents
+                      {agents && agents[selectedAgent]
                         ? agents[selectedAgent].Network.map((network) =>
                             network.Addresses?.filter(
                               (address) =>


### PR DESCRIPTION
Fix the "cannot read properties of undefined (reading 'map')" when logging in to the web UI

# 🚀 Title

## 🎯 Description

Fix the annoying error when logging in "Cannot read properties of undefined (reading map)"

## 📝 Checklist

- [X] I have performed a self-review of my code.
- [X] I have documented my changes if necessary.
- [X] I have tested the changes in a local environment.


## 🔍 Testing Instructions

1. Go to http://127.0.0.1:8080
2. Enter API + user + password
3. See there is not anymore the error message right after login validation

## 🛠️ Types of Changes

<!-- Please remove the options that are not relevant and add any relevant information. -->

- 🐛 Bug fix (non-breaking change which fixes an issue)
- 💡 Enhancement (improvement of an existing feature)

## 💬 Comments

<!-- Add any additional comments or context about the PR here. -->

---